### PR TITLE
Run deploy job on push event only

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,6 +65,7 @@ jobs:
     timeout-minutes: 5
     needs: build
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' }}
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v2


### PR DESCRIPTION
Deploy job is run only on push event on main branch